### PR TITLE
Add the Paper plugin

### DIFF
--- a/McMerchantsChatPlugin/.gitignore
+++ b/McMerchantsChatPlugin/.gitignore
@@ -1,8 +1,10 @@
 .gradle
 build/
-!gradle/wrapper/gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+gradlew
+gradlew.bat
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/McMerchantsChatPlugin/.gitignore
+++ b/McMerchantsChatPlugin/.gitignore
@@ -1,0 +1,45 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+### Test server ###
+run/

--- a/McMerchantsChatPlugin/.idea/.gitignore
+++ b/McMerchantsChatPlugin/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/McMerchantsChatPlugin/.idea/codeStyles/codeStyleConfig.xml
+++ b/McMerchantsChatPlugin/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/McMerchantsChatPlugin/.idea/gradle.xml
+++ b/McMerchantsChatPlugin/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/McMerchantsChatPlugin/.idea/inspectionProfiles/Project_Default.xml
+++ b/McMerchantsChatPlugin/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  </profile>
+</component>

--- a/McMerchantsChatPlugin/.idea/misc.xml
+++ b/McMerchantsChatPlugin/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="ms-21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/McMerchantsChatPlugin/.idea/vcs.xml
+++ b/McMerchantsChatPlugin/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/McMerchantsChatPlugin/build.gradle.kts
+++ b/McMerchantsChatPlugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "net.baviereteam.mcmerchants"
-version = "1.0-SNAPSHOT"
+version = "MC_1.21.10"
 
 repositories {
     maven {

--- a/McMerchantsChatPlugin/build.gradle.kts
+++ b/McMerchantsChatPlugin/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("java")
+    id("xyz.jpenilla.run-paper") version "2.3.1"
+}
+
+group = "net.baviereteam.mcmerchants"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven {
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
+    implementation("com.fasterxml.jackson.core", "jackson-databind", "2.20.1")
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+tasks {
+    runServer {
+        // Configure the Minecraft version for our task.
+        // This is the only required configuration besides applying the plugin.
+        // Your plugin's jar (or shadowJar if present) will be used automatically.
+        minecraftVersion("1.21.10")
+        jvmArgs("-Dcom.mojang.eula.agree=true")
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.jar {
+    manifest {
+        attributes["paperweight-mappings-namespace"] = "mojang"
+    }
+}

--- a/McMerchantsChatPlugin/gradle/wrapper/gradle-wrapper.properties
+++ b/McMerchantsChatPlugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Sun Mar 09 01:16:07 CET 2025
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/McMerchantsChatPlugin/settings.gradle.kts
+++ b/McMerchantsChatPlugin/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "mcmerchants"
+

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/McMerchantsService.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/McMerchantsService.java
@@ -1,0 +1,51 @@
+package net.baviereteam.mcmerchants;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.baviereteam.mcmerchants.json.ResponseRoot;
+
+public class McMerchantsService {
+	private final String apiUrl;
+
+	public McMerchantsService(String baseUrl) {
+		this.apiUrl = baseUrl.strip() + "/api/stock/%s";
+	}
+	
+	public CompletableFuture<QueryResult> query(String item) {
+		return executeRequest(item)
+				.thenApply(this::craftResult);
+	}
+
+	private CompletableFuture<String> executeRequest(String arg) {
+		HttpClient client = HttpClient.newHttpClient();
+		HttpRequest request = HttpRequest.newBuilder()
+				.uri(URI.create(apiUrl.formatted(arg)))
+				.build();
+
+		// i'd like this to return an async but when it resolves, it has the parsed string
+		return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+				.thenApply(HttpResponse::body);
+	}
+
+	private QueryResult craftResult(String json) {
+		QueryResult result;
+
+		try {
+			result = new QueryResult(deserializeResult(json));
+		} catch (JsonProcessingException e) {
+			result = new QueryResult(e);
+		}
+
+		return result;
+	}
+
+	private ResponseRoot deserializeResult(String input) throws JsonProcessingException {
+		ObjectMapper mapper = new ObjectMapper();
+		return mapper.readValue(input, ResponseRoot.class);
+	}
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/QueryResult.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/QueryResult.java
@@ -1,0 +1,25 @@
+package net.baviereteam.mcmerchants;
+
+import net.baviereteam.mcmerchants.json.ResponseRoot;
+
+public class QueryResult {
+	private ResponseRoot response;
+	private Throwable error;
+	
+	public QueryResult(ResponseRoot response) {
+		this.response = response;
+	}
+	public QueryResult(Throwable error) {
+		this.error = error;
+	}
+	
+	public boolean hasError() {
+		return this.error != null;
+	}
+	public Throwable getError() {
+		return this.error;
+	}
+	public ResponseRoot getResponse() {
+		return this.response;
+	}
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Alley.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Alley.java
@@ -1,0 +1,15 @@
+package net.baviereteam.mcmerchants.json;
+
+public class Alley{
+	public String name;
+	public int count;
+	/*
+		type="default" for default alley
+		type="bulk" for bulk
+		type=null for other alleys
+	 */
+	public String type;
+	public int x;
+	public int y;
+	public int z;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Enchantment.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Enchantment.java
@@ -1,0 +1,6 @@
+package net.baviereteam.mcmerchants.json;
+
+public class Enchantment {
+	public String name;
+	public int level;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Factory.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Factory.java
@@ -1,0 +1,9 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class Factory{
+	public String name;
+	public String logo;
+	public ArrayList<FactoryResult> results;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/FactoryResult.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/FactoryResult.java
@@ -1,0 +1,8 @@
+package net.baviereteam.mcmerchants.json;
+
+public class FactoryResult {
+	public int x;
+	public int y;
+	public int z;
+	public int count;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/ResponseRoot.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/ResponseRoot.java
@@ -1,0 +1,10 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class ResponseRoot {
+	public boolean complete;
+	public ArrayList<Store> stores;
+	public ArrayList<Factory> factories;
+	public ArrayList<Trader> traders;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Sell.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Sell.java
@@ -1,0 +1,10 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class Sell{
+	public String item;
+	public String id;
+	public int quantity;
+	public ArrayList<Object> enchantments;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Store.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Store.java
@@ -1,0 +1,9 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class Store{
+	public String name;
+	public String logo;
+	public ArrayList<Alley> alleys;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/TradeComponent.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/TradeComponent.java
@@ -1,0 +1,10 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class TradeComponent {
+	public String item;
+	public String id;
+	public int quantity;
+	public ArrayList<Enchantment> enchantments;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Trader.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Trader.java
@@ -1,0 +1,10 @@
+package net.baviereteam.mcmerchants.json;
+
+import java.util.ArrayList;
+
+public class Trader{
+	public int id;
+	public String name;
+	public String logo;
+	public ArrayList<TraderResult> results;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/TraderResult.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/TraderResult.java
@@ -1,0 +1,8 @@
+package net.baviereteam.mcmerchants.json;
+
+public class TraderResult {
+	public Villager villager;
+	public TradeComponent buy1;
+	public TradeComponent buy2;
+	public TradeComponent sell;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Villager.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchants/json/Villager.java
@@ -1,0 +1,8 @@
+package net.baviereteam.mcmerchants.json;
+
+public class Villager{
+	public String job;
+	public int x;
+	public int y;
+	public int z;
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchantschatplugin/McMerchantsChatPlugin.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchantschatplugin/McMerchantsChatPlugin.java
@@ -1,0 +1,197 @@
+package net.baviereteam.mcmerchantschatplugin;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import net.baviereteam.mcmerchants.McMerchantsService;
+import net.baviereteam.mcmerchants.QueryResult;
+import net.baviereteam.mcmerchants.json.Alley;
+import net.baviereteam.mcmerchants.json.FactoryResult;
+import net.baviereteam.mcmerchants.json.ResponseRoot;
+import net.baviereteam.mcmerchants.json.Trader;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.apache.commons.lang3.ObjectUtils;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class McMerchantsChatPlugin extends JavaPlugin {
+	public McMerchantsService mcMerchantsClient;
+
+	public McMerchantsChatPlugin() {
+		
+	}
+
+	@Override
+	public void onEnable() {
+		saveDefaultConfig();
+		
+		try {
+			mcMerchantsClient = new McMerchantsService(this.getConfig().get("mcmerchants_url").toString());
+			this.getLifecycleManager().registerEventHandler(
+					LifecycleEvents.COMMANDS,
+					event -> event.registrar().register(McmCommandBuilder.getMcmCommand(this))
+			);
+			
+		} catch (NullPointerException e) {
+			getComponentLogger().error(Component.text("Could not register McMerchants URL. Make sure it is correctly set in your configuration file."));
+		}
+	}
+
+	public int onCommand(CommandContext<CommandSourceStack> context) {
+		final org.bukkit.entity.Entity executor = context.getSource().getExecutor();
+		final ItemType itemType = context.getArgument("item", ItemType.class);
+		queryMcMerchantsAndShowResults(executor, itemType);
+		return Command.SINGLE_SUCCESS;
+	}
+
+	public void logFailure(String text) {
+		this.getComponentLogger().warn(Component.text(text));
+	}
+
+	public void queryMcMerchantsAndShowResults(Entity executor, ItemType itemType) {
+		CompletableFuture<QueryResult> futureResult = mcMerchantsClient.query(itemType.getKey().toString());
+		futureResult.thenAccept(data -> {
+			if (data.hasError()) {
+				logFailure(data.getError().toString());
+				sendFailAnswer(executor);
+
+			} else {
+				ResponseRoot response = data.getResponse();
+				Component answer = craftSuccessAnswer(itemType.getKey().toString(), response);
+				broadcastSuccessAnswer(answer);
+			}
+		});
+	}
+
+	public void sendFailAnswer(Entity executor) {
+		if (executor != null) {
+			executor.sendMessage("McMerchants did not answer properly :(");
+		}
+	}
+	public void broadcastSuccessAnswer(Component answer) {
+		getServer().sendMessage(answer);
+	}
+
+	public Component craftSuccessAnswer(String searchedItemName, ResponseRoot response) {
+		AtomicBoolean foundAtLeastOnce = new AtomicBoolean(false);
+
+		StringBuilder answer = new StringBuilder();
+		answer
+				.append("<u><b>McMerchants request for <yellow>")
+				.append(searchedItemName)
+				.append("</yellow></b></u>\n");
+
+		if (!response.complete) {
+			answer.append("<red>Some chunks could not be read. The results displayed here might be incomplete.</red>\n");
+		}
+		
+		// this lists all the existing stores even if they don't carry it
+		if (!response.stores.isEmpty()) {
+			answer.append("> Stores:\n");
+			response.stores.forEach(store -> {
+				int total = store.alleys.stream().reduce(
+						0,
+						(accumulator, alley) -> accumulator + alley.count,
+						Integer::sum);
+
+				if (total == 0) {
+					answer
+							.append("  - <b>none</b> in <light_purple>")
+							.append(store.name)
+							.append("</light_purple>");
+					
+				} else {
+					String alleyNames = store.alleys.stream()
+							.filter(alley -> alley.count > 0)
+							.reduce(
+									"",
+									(accumulator, alley) -> {
+										return accumulator + " " + (alley.type.equals("bulk") ? "bulk" : alley.name);
+									},
+									String::concat
+							);
+					
+					answer
+						.append("  - <b>")
+						.append(total)
+						.append("</b> in <light_purple>")
+						.append(store.name)
+						.append("</light_purple> (")
+						.append(alleyNames.trim())
+						.append(")");
+				}
+				
+				answer.append("\n");
+			});
+		}
+
+		// This only lists factories that produce it
+		answer.append("> Factories: ");
+		if (response.factories.isEmpty()) {
+			answer.append("<b>none</b> producing this item\n");
+			
+		} else {
+			answer.append("\n");
+			
+			response.factories.forEach(factory -> {
+				int total = factory.results.stream().reduce(
+						0,
+						(accumulator, factoryResult) -> accumulator + factoryResult.count,
+						Integer::sum);
+
+				if (total == 0) {
+					answer
+							.append("  - <b>none</b> in <light_purple>")
+							.append(factory.name)
+							.append("</light_purple>\n");
+					
+				} else {
+					answer
+							.append("  - <b>")
+							.append(total)
+							.append("</b> in <light_purple>")
+							.append(factory.name)
+							.append("</light_purple>\n");
+				}
+			});
+		}
+
+		// this is a list of all trading zones even if they don't have a trade for this
+		if (!response.traders.isEmpty()) {
+			answer.append("> Trading zones: ");
+			List<Trader> tradingZonesWithThisItem =
+					response.traders
+							.stream()
+							.filter(
+									trader -> !trader.results.isEmpty())
+							.toList();
+
+			if (tradingZonesWithThisItem.isEmpty()) {
+				answer.append("<b>none</b> with this item\n");
+				
+			} else {
+				answer.append("\n");
+				
+				response.traders.forEach(trader -> {
+					if (!trader.results.isEmpty()) {
+						answer
+								.append("  - <b>")
+								.append(trader.results.size())
+								.append("</b> trades in <light_purple>")
+								.append(trader.name)
+								.append("</light_purple>\n");
+					}
+				});
+			}
+		}
+
+		return MiniMessage.miniMessage().deserialize(answer.toString());
+	}
+}

--- a/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchantschatplugin/McmCommandBuilder.java
+++ b/McMerchantsChatPlugin/src/main/java/net/baviereteam/mcmerchantschatplugin/McmCommandBuilder.java
@@ -1,0 +1,18 @@
+package net.baviereteam.mcmerchantschatplugin;
+
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.registry.RegistryKey;
+
+public class McmCommandBuilder {
+    public static LiteralCommandNode<CommandSourceStack> getMcmCommand(McMerchantsChatPlugin plugin) {
+        return Commands.literal("mcm")
+            .then(Commands
+                .argument("item", ArgumentTypes.resource(RegistryKey.ITEM))
+                .executes(plugin::onCommand)
+            )
+            .build();
+    }
+}

--- a/McMerchantsChatPlugin/src/main/resources/config.yml
+++ b/McMerchantsChatPlugin/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+# The base URL for McMerchants (no trailing slash) 
+mcmerchants_url: ~

--- a/McMerchantsChatPlugin/src/main/resources/plugin.yml
+++ b/McMerchantsChatPlugin/src/main/resources/plugin.yml
@@ -1,0 +1,11 @@
+name: McMerchantsChatPlugin
+version: 1.1.0
+main: net.baviereteam.mcmerchantschatplugin.McMerchantsChatPlugin
+description: Allows access to a McMerchants instance from the in-game chat.
+author: baviereteam
+website: https://github.com/baviereteam
+api-version: '1.21.10'
+commands:
+  mcm:
+    description: Search in McMerchants
+    usage: /mcm <item>


### PR DESCRIPTION
This adds the source for a Paper server plugin that lets you query items from McMerchants straight from the game.

- McMerchants URL base must be configured in `plugins/McMerchantsChatPlugin/config.yml` (generated at first launch)
- In-game: use the command `/mcm` followed by the Minecraft ID of the item you want to search (the command provides autocompletion).
- 
Potion types and enchanted book types are not supported yet.